### PR TITLE
Remove aliases not used by SCKAN connectivity, and annotate or remove nerve cuffs to prevent unnecessary rasterisation.

### DIFF
--- a/anatomical_map.json
+++ b/anatomical_map.json
@@ -1447,10 +1447,6 @@
         "term": "UBERON:0005453",
         "name": "inferior mesenteric ganglion"
     },
-    "ganglion_8": {
-        "term": "UBERON:0001808",
-        "name": "parasympathetic ganglion"
-    },
     "ganglion_9": {
         "term": "UBERON:0001990",
         "name": "middle cervical ganglion"

--- a/connectivity_terms.json
+++ b/connectivity_terms.json
@@ -1,159 +1,5 @@
 [
     {
-        "id": "UBERON:0001508",
-        "name": "arch of aorta",
-        "aliases": [
-            "ILX:0738302"
-        ]
-    },
-    {
-        "id": "UBERON:0001629",
-        "name": "carotid body",
-        "aliases": [
-            "ILX:0736966"
-        ]
-    },
-    {
-        "id": "UBERON:0003708",
-        "name": "carotid sinus",
-        "aliases": [
-            "ILX:0731873"
-        ]
-    },
-    {
-        "id": "UBERON:0001894",
-        "name": "diencephalon",
-        "aliases": [
-            "ILX:0103217"
-        ]
-    },
-    {
-        "id": "UBERON:0000388",
-        "name": "epiglottis",
-        "aliases": [
-            "ILX:0103886"
-        ]
-    },
-    {
-        "id": "UBERON:0001649",
-        "name": "glossopharyngeal nerve",
-        "aliases": [
-            "ILX:0723837"
-        ]
-    },
-    {
-        "id": "UBERON:0001898",
-        "name": "hypothalamus",
-        "aliases": [
-            "ILX:0105177"
-        ]
-    },
-    {
-        "id": "UBERON:0001532",
-        "name": "internal carotid artery",
-        "aliases": [
-            "ILX:0736647"
-        ]
-    },
-    {
-        "id": "UBERON:0001737",
-        "name": "larynx",
-        "aliases": [
-            "ILX:0727818"
-        ]
-    },
-    {
-        "id": "UBERON:0001896",
-        "name": "medulla oblongata",
-        "aliases": [
-            "ILX:0738301"
-        ]
-    },
-    {
-        "id": "UBERON:0001891",
-        "name": "midbrain",
-        "aliases": [
-            "ILX:0106935"
-        ]
-    },
-    {
-        "id": "UBERON:0001990",
-        "name": "middle cervical ganglion",
-        "aliases": [
-            "ILX:0726454"
-        ]
-    },
-    {
-        "id": "UBERON:0004982",
-        "name": "mucosa of epiglottis",
-        "aliases": [
-            "ILX:0736652"
-        ]
-    },
-    {
-        "id": "UBERON:0005020",
-        "name": "mucosa of tongue",
-        "aliases": [
-            "ILX:0731712"
-        ]
-    },
-    {
-        "id": "UBERON:0009050",
-        "name": "nucleus of solitary tract",
-        "aliases": [
-            "ILX:0738323"
-        ]
-    },
-    {
-        "id": "UBERON:0001884",
-        "name": "phrenic nerve",
-        "aliases": [
-            "ILX:0736057"
-        ]
-    },
-    {
-        "id": "UBERON:0000988",
-        "name": "pons",
-        "aliases": [
-            "ILX:0109019"
-        ]
-    },
-    {
-        "id": "UBERON:0001989",
-        "name": "superior cervical ganglion",
-        "aliases": [
-            "ILX:0725956"
-        ]
-    },
-    {
-        "id": "UBERON:0011326",
-        "name": "superior laryngeal nerve",
-        "aliases": [
-            "ILX:0731053"
-        ]
-    },
-    {
-        "id": "UBERON:0001723",
-        "name": "tongue",
-        "aliases": [
-            "ILX:0111810"
-        ]
-    },
-    {
-        "id": "UBERON:0003126",
-        "name": "trachea",
-        "aliases": [
-            "ILX:0729183"
-        ]
-    },
-    {
-        "id": "UBERON:0001759",
-        "name": "vagus nerve",
-        "aliases": [
-            "ILX:0733375"
-        ]
-    },
-    {
         "id": [
             "UBERON:0007240",
             [
@@ -1106,6 +952,10 @@
             [
                 "ILX:0794769",
                 []
+            ],
+            [
+                "ILX:0794767",
+                []
             ]
         ]
     },
@@ -1118,6 +968,10 @@
         "aliases": [
             [
                 "ILX:0794770",
+                []
+            ],
+            [
+                "ILX:0794766",
                 []
             ]
         ]
@@ -1180,45 +1034,6 @@
         "aliases": [
             [
                 "ILX:0794738",
-                []
-            ]
-        ]
-    },
-    {
-        "id": [
-            "ILX:0793769",
-            ["UBERON:0000002"]
-        ],
-        "name": "smooth muscle/uterine cervix",
-        "aliases": [
-            [
-                "ILX:0794768",
-                []
-            ]
-        ]
-    },
-    {
-        "id": [
-            "UBERON:0001981",
-            ["UBERON:0000002"]
-        ],
-        "name": "blood vessel/uterine cervix",
-        "aliases": [
-            [
-                "ILX:0794766",
-                []
-            ]
-        ]
-    },
-    {
-        "id": [
-            "ILX:0793769",
-            ["UBERON:0009853"]
-        ],
-        "name": "smooth muscle/body of uterus",
-        "aliases": [
-            [
-                "ILX:0794767",
                 []
             ]
         ]
@@ -1314,19 +1129,6 @@
         "aliases": [
             [
                 "ILX:0731969",
-                []
-            ]
-        ]
-    },
-    {
-        "id": [
-            "ILX:0793218",
-            []
-        ],
-        "name": "white communicating ramus of twelfth thoracic spinal nerve",
-        "aliases": [
-            [
-                "TEMP:MISSING_white-communicating-ramus",
                 []
             ]
         ]

--- a/properties.json
+++ b/properties.json
@@ -3612,7 +3612,8 @@
             "models": "ILX:0738309"
         },
         "recurrent_laryngeal_17": {
-            "type": "nerve"
+            "type": "nerve",
+            "models": "ILX:0738308"
         },
         "superior_laryngeal_1": {
             "type": "nerve",
@@ -3879,6 +3880,27 @@
         "tympanic_c": {
             "type": "nerve",
             "models": "UBERON:0036216"
+        },
+        "ardell_1_c": {
+            "type": "nerve"
+        },
+        "ardell_4_c": {
+            "type": "nerve"
+        },
+        "ardell_5_c": {
+            "type": "nerve"
+        },
+        "ardell_6_c": {
+            "type": "nerve"
+        },
+        "n_76_c": {
+            "type": "nerve"
+        },
+        "n_77_c": {
+            "type": "nerve"
+        },
+        "bolser_9_c": {
+            "type": "nerve"
         }
     },
     "networks": [

--- a/properties.json
+++ b/properties.json
@@ -6,9 +6,6 @@
         "ganglion_7": {
             "label": "ventricular intracardiac ganglion"
         },
-        "ganglion_8": {
-            "label": "mediastinal ganglion"
-        },
         "label_1": {
             "label": "dura mater in the posterior cranial fossa"
         },
@@ -1952,7 +1949,10 @@
             "class": "spinal_51"
         },
         "ganglion_8-1": {
-            "class": "ganglion_8"
+            "models": "UBERON:0001808",
+            "name": "parasympathetic ganglion",
+            "type": "ganglion",
+            "class": "auto-hide"
         },
         "ganglion_9-1": {
             "class": "ganglion_9"


### PR DESCRIPTION
- Remove unused aliases (e.g., those not used in SCKAN nodes)
- Remove or update reference aliases not available in the map